### PR TITLE
Delegate interest rate logic to a controller

### DIFF
--- a/contracts/AutomatedLineOfCreditFactory.sol
+++ b/contracts/AutomatedLineOfCreditFactory.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IRateComputer} from "@adrastia-oracle/adrastia-periphery/contracts/rates/IRateComputer.sol";
 import {IAutomatedLineOfCredit} from "./interfaces/IAutomatedLineOfCredit.sol";
 import {PortfolioFactory} from "./PortfolioFactory.sol";
 import {ITransferController} from "./interfaces/ITransferController.sol";
@@ -26,6 +27,10 @@ contract AutomatedLineOfCreditFactory is PortfolioFactory {
         address transferControllerImplementation;
         /// @dev Encoded args with initialize method selector from transfer controller
         bytes transferControllerInitData;
+        /// @dev Implementation of the controller used when calling interest rate-related functions
+        address interestRateControllerImplementation;
+        /// @dev Encoded args with initialize method selector from interest rate controller
+        bytes interestRateControllerInitData;
     }
 
     function createPortfolio(
@@ -63,11 +68,15 @@ contract AutomatedLineOfCreditFactory is PortfolioFactory {
         address transferController = Clones.clone(controllersData.transferControllerImplementation);
         transferController.functionCall(controllersData.transferControllerInitData);
 
+        address interestRateController = Clones.clone(controllersData.interestRateControllerImplementation);
+        interestRateController.functionCall(controllersData.interestRateControllerInitData);
+
         return
             IAutomatedLineOfCredit.Controllers(
                 IDepositController(depositController),
                 IWithdrawController(withdrawController),
-                ITransferController(transferController)
+                ITransferController(transferController),
+                IRateComputer(interestRateController)
             );
     }
 }

--- a/contracts/controllers/LinearKinkInterestRateController.sol
+++ b/contracts/controllers/LinearKinkInterestRateController.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {IRateComputer} from "@adrastia-oracle/adrastia-periphery/contracts/rates/IRateComputer.sol";
+
+interface PortfolioWithUtilizationRate {
+    function utilization() external view returns (uint256);
+}
+
+contract LinearKinkInterestRateController is IRateComputer, IERC165 {
+    using SafeCast for uint256;
+
+    struct InterestRateParameters {
+        uint32 minInterestRate;
+        uint32 minInterestRateUtilizationThreshold;
+        uint32 optimumInterestRate;
+        uint32 optimumUtilization;
+        uint32 maxInterestRate;
+        uint32 maxInterestRateUtilizationThreshold;
+    }
+
+    InterestRateParameters public interestRateParameters;
+
+    constructor(InterestRateParameters memory _interestRateParameters) {
+        interestRateParameters = _interestRateParameters;
+    }
+
+    function getInterestRateParameters()
+        public
+        view
+        returns (
+            uint32,
+            uint32,
+            uint32,
+            uint32,
+            uint32,
+            uint32
+        )
+    {
+        InterestRateParameters memory _interestRateParameters = interestRateParameters;
+        return (
+            _interestRateParameters.minInterestRate,
+            _interestRateParameters.minInterestRateUtilizationThreshold,
+            _interestRateParameters.optimumInterestRate,
+            _interestRateParameters.optimumUtilization,
+            _interestRateParameters.maxInterestRate,
+            _interestRateParameters.maxInterestRateUtilizationThreshold
+        );
+    }
+
+    function computeRate(address portfolio) external view returns (uint64) {
+        return computeRateInternal(portfolio).toUint64();
+    }
+
+    function supportsInterface(bytes4 interfaceID) public view override returns (bool) {
+        return (interfaceID == type(IRateComputer).interfaceId || interfaceID == type(IERC165).interfaceId);
+    }
+
+    function computeRateInternal(address portfolio) internal view returns (uint256) {
+        uint256 currentUtilization = PortfolioWithUtilizationRate(portfolio).utilization();
+        (
+            uint32 minInterestRate,
+            uint32 minInterestRateUtilizationThreshold,
+            uint32 optimumInterestRate,
+            uint32 optimumUtilization,
+            uint32 maxInterestRate,
+            uint32 maxInterestRateUtilizationThreshold
+        ) = getInterestRateParameters();
+        if (currentUtilization <= minInterestRateUtilizationThreshold) {
+            return minInterestRate;
+        } else if (currentUtilization <= optimumUtilization) {
+            return
+                solveLinear(
+                    currentUtilization,
+                    minInterestRateUtilizationThreshold,
+                    minInterestRate,
+                    optimumUtilization,
+                    optimumInterestRate
+                );
+        } else if (currentUtilization <= maxInterestRateUtilizationThreshold) {
+            return
+                solveLinear(
+                    currentUtilization,
+                    optimumUtilization,
+                    optimumInterestRate,
+                    maxInterestRateUtilizationThreshold,
+                    maxInterestRate
+                );
+        } else {
+            return maxInterestRate;
+        }
+    }
+
+    function solveLinear(
+        uint256 x,
+        uint256 x1,
+        uint256 y1,
+        uint256 x2,
+        uint256 y2
+    ) internal pure returns (uint256) {
+        return (y1 * (x2 - x) + y2 * (x - x1)) / (x2 - x1);
+    }
+}

--- a/contracts/interfaces/IAutomatedLineOfCredit.sol
+++ b/contracts/interfaces/IAutomatedLineOfCredit.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IRateComputer} from "@adrastia-oracle/adrastia-periphery/contracts/rates/IRateComputer.sol";
 import {IProtocolConfig} from "./IProtocolConfig.sol";
 import {IPortfolio} from "./IPortfolio.sol";
 import {IDepositController} from "./IDepositController.sol";
@@ -28,6 +29,7 @@ interface IAutomatedLineOfCredit is IPortfolio {
         IDepositController depositController;
         IWithdrawController withdrawController;
         ITransferController transferController;
+        IRateComputer interestRateController;
     }
 
     function initialize(

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "typescript": "4.9.4"
   },
   "dependencies": {
+    "@adrastia-oracle/adrastia-periphery": "^4.1.0",
     "@openzeppelin/contracts": "4.6.0",
     "@openzeppelin/contracts-upgradeable": "4.4.2",
     "merkletreejs": "^0.2.31"


### PR DESCRIPTION
This PR removes interest rate computation from `AutomatedLineOfCredit` and delegates to a controller to provide this calculation. This allows for plug-and-play functionality of interest rate controllers.

The old logic of interest rate calculation for `AutomatedLineOfCredit` has been extracted into a controller named `LinearKinkInterestRateController`.

More consideration of the constructor parameters and various getter functions for `AutomatedLineOfCredit` is needed, specifically with `_interestRateParameters` as only the optimal utilization rate is relevant.